### PR TITLE
Updated composer package reference

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -19,7 +19,7 @@ before using Sereno make sure you have composer installed on your machine.
 
 Install Sereno by issuing the Composer `create-project` command in your terminal:
 
-    composer create-project --prefer-dist znck/sereno blog
+    composer create-project --prefer-dist sereno/core blog
 
 #### Post Installation
 Sereno uses [Gulp](#) to build resources. So, make sure you have Node installed


### PR DESCRIPTION
The current docs recommend that users install the composer package znck/sereno.

Upon installation, Composer warns that znck/sereno is abandoned and to use sereno/core instead.

This is a change to the docs reflecting that warning.